### PR TITLE
GET for teams done

### DIFF
--- a/app/api/team/route.ts
+++ b/app/api/team/route.ts
@@ -1,0 +1,15 @@
+import prisma from "@/lib/prismadb";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  try {
+    const teams = await prisma.team.findMany();
+    return NextResponse.json(teams, { status: 200 });
+  } catch (error) {
+    console.error("Error fetching teams:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch teams" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new API route to fetch team data from the database. The `GET` method retrieves all teams using Prisma and handles errors gracefully.

Key changes:

### New API Route Implementation:
* [`app/api/team/route.ts`](diffhunk://#diff-f5cc4201571c8762b0457dc14a75fcfbae08af445c479e2ca18c650b1af09f01R1-R15): Added a `GET` method to fetch all teams from the database using Prisma. The response includes a JSON object with the team data or an error message in case of failure.