### PR TITLE
updated user fields

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,15 +19,18 @@ enum Role {
 }
 
 model User {
-  id           String   @id @default(auto()) @map("_id") @db.ObjectId
-  email        String?  @unique
-  name         String
-  hashPassword String?
-  bio          String?
-  imgUrl       String?
-  role         Role     @default(Admin)
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id             String   @id @default(auto()) @map("_id") @db.ObjectId
+  email          String?  
+  name           String
+  hashPassword   String?
+  duties         String?
+  yearsOnCrew    String?
+  favoriteMemory String?
+  birthday       String?
+  imgUrl         String?
+  role           Role     @default(Admin)
+  createdAt      DateTime @default(now())
+  updatedAt      DateTime @updatedAt
 
   pictures Picture[]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -9,25 +9,25 @@ async function main() {
   //   },
   // });
 
-  await prisma.game.createMany({
-    data: [
-      {
-        date: new Date("2025-07-20T20:00:00Z"),
-        location: "Home",
-        opponentId: "6862ec5f5d61f8ec387dc289",
-      },
-      {
-        date: new Date("2025-07-25T20:00:00Z"),
-        location: "Away",
-        opponentId: "6862ec5f5d61f8ec387dc28d",
-      },
-      {
-        date: new Date("2025-07-30T20:00:00Z"),
-        location: "Home",
-        opponentId: "6862ec5f5d61f8ec387dc295",
-      },
-    ],
-  });
+  // await prisma.game.createMany({
+  //   data: [
+  //     {
+  //       date: new Date("2025-07-20T20:00:00Z"),
+  //       location: "Home",
+  //       opponentId: "6862ec5f5d61f8ec387dc289",
+  //     },
+  //     {
+  //       date: new Date("2025-07-25T20:00:00Z"),
+  //       location: "Away",
+  //       opponentId: "6862ec5f5d61f8ec387dc28d",
+  //     },
+  //     {
+  //       date: new Date("2025-07-30T20:00:00Z"),
+  //       location: "Home",
+  //       opponentId: "6862ec5f5d61f8ec387dc295",
+  //     },
+  //   ],
+  // });
 
   // await prisma.fAQ.createMany({
   //   data: [
@@ -69,6 +69,16 @@ async function main() {
   //     },
   //   ],
   // });
+
+  await prisma.user.updateMany({
+    where: {},
+    data: {
+      duties: null,
+      yearsOnCrew: null,
+      favoriteMemory: null,
+      birthday: null,
+    },
+  });
 
   return "Seed completed successfully!";
 }


### PR DESCRIPTION
This pull request updates the `User` model in the Prisma schema to replace the `bio` field with more specific fields and adjusts the seed script to match these changes. It also comments out the seeding of `game` data and adds a step to update all users with the new fields set to `null`.

**Database schema updates:**

* Replaced the `bio` field in the `User` model with new fields: `duties`, `yearsOnCrew`, `favoriteMemory`, and `birthday` in `prisma/schema.prisma`. The `email` field is no longer unique.

**Seed script changes:**

* Commented out the creation of `game` records in the seed script, so no games are seeded by default.
* Added a step to update all users, setting the new `duties`, `yearsOnCrew`, `favoriteMemory`, and `birthday` fields to `null` in `prisma/seed.ts`.