### PR TITLE
made email unique

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ enum Role {
 
 model User {
   id             String   @id @default(auto()) @map("_id") @db.ObjectId
-  email          String?  
+  email          String  @unique
   name           String
   hashPassword   String?
   duties         String?


### PR DESCRIPTION
This pull request makes a small but important change to the `User` model in the Prisma schema by making the `email` field required and unique, which will help ensure data integrity and prevent duplicate user entries.