### PR TITLE
all tabs done

### DIFF
--- a/components/charitiesPage/charitiesPage.tsx
+++ b/components/charitiesPage/charitiesPage.tsx
@@ -4,6 +4,9 @@ import * as React from "react";
 import Tabs from "@mui/material/Tabs";
 import Tab from "@mui/material/Tab";
 import Box from "@mui/material/Box";
+import HopeKidsTab from "./tabs/hopeKidsTab";
+import McDonaldHouseTab from "./tabs/mcDonaldHouseTab";
+import ArisFoundation from "./tabs/arisFoundation";
 
 interface TabPanelProps {
   children?: React.ReactNode;
@@ -22,7 +25,11 @@ function CustomTabPanel(props: TabPanelProps) {
       aria-labelledby={`simple-tab-${index}`}
       {...other}
     >
-      {value === index && <Box sx={{ p: 3 }}>{children}</Box>}
+      {value === index && (
+        <Box sx={{ p: 3 }} className="flex justify-center">
+          {children}
+        </Box>
+      )}
     </div>
   );
 }
@@ -66,13 +73,13 @@ export default function CharitiesPage() {
         </Tabs>
       </Box>
       <CustomTabPanel value={value} index={0}>
-        Item One
+        <HopeKidsTab />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={1}>
-        Item Two
+        <McDonaldHouseTab />
       </CustomTabPanel>
       <CustomTabPanel value={value} index={2}>
-        Item Three
+        <ArisFoundation />
       </CustomTabPanel>
     </main>
   );

--- a/components/charitiesPage/tabs/arisFoundation.tsx
+++ b/components/charitiesPage/tabs/arisFoundation.tsx
@@ -1,0 +1,12 @@
+export default function ArisFoundation() {
+  return (
+    <section className="flex flex-col items-center w-full gap-2 md:gap-4 lg:gap-6 xl:gap-8 text-center max-w-5xl">
+      <h2 className="font-bold text-lg md:text-xl lg:text-2xl xl:text-3xl">
+        Aris Foundation
+      </h2>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        More info coming soon!
+      </p>
+    </section>
+  );
+}

--- a/components/charitiesPage/tabs/hopeKidsTab.tsx
+++ b/components/charitiesPage/tabs/hopeKidsTab.tsx
@@ -1,0 +1,36 @@
+export default function HopeKidsTab() {
+  return (
+    <section className="flex flex-col items-center w-full gap-2 md:gap-4 lg:gap-6 xl:gap-8 text-center max-w-5xl">
+      <h2 className="font-bold text-lg md:text-xl lg:text-2xl xl:text-3xl">
+        HopeKids, Inc.
+      </h2>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        The Pro Football's Ultimate Fan Association (PFUFA) is made up of big
+        fans with even bigger hearts, and they&apos;re once again teaming up to
+        make a difference!
+      </p>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        For the 5th annual Tailgate Challenge, PFUFA superfans from the Kansas
+        City Chiefs, Denver Broncos, Minnesota Vikings, Dallas Cowboys, Arizona
+        Cardinals and Carolina Panthers are taking their passion beyond the
+        stadium to support children with life-threatening medical conditions.
+      </p>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        Their goal? To raise funds for HopeKids and provide a continuous
+        calendar of events that gives families something to look forward to,
+        especially during their hardest days.
+      </p>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        <a
+          href="https://give.hopekids.org/team/763266"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-500 underline hover:text-blue-700"
+        >
+          Donate
+        </a>{" "}
+        to help us achieve this goal.
+      </p>
+    </section>
+  );
+}

--- a/components/charitiesPage/tabs/mcDonaldHouseTab.tsx
+++ b/components/charitiesPage/tabs/mcDonaldHouseTab.tsx
@@ -1,0 +1,12 @@
+export default function McDonaldHouseTab() {
+  return (
+    <section className="flex flex-col items-center w-full gap-2 md:gap-4 lg:gap-6 xl:gap-8 text-center max-w-5xl">
+      <h2 className="font-bold text-lg md:text-xl lg:text-2xl xl:text-3xl">
+        Ronald McDonald House
+      </h2>
+      <p className="md:text-lg lg:text-xl xl:text-2xl">
+        More info coming soon!
+      </p>
+    </section>
+  );
+}


### PR DESCRIPTION
This pull request updates the `CharitiesPage` to display dedicated tab components for three charities, providing more structured and styled content for each tab. The main improvements include replacing placeholder text with new tab components, adding content for HopeKids, and introducing placeholder sections for the other two charities.

**Charities tab content enhancements:**

* Replaced placeholder tab content in `CharitiesPage` with three new components: `HopeKidsTab`, `McDonaldHouseTab`, and `ArisFoundation`, each rendered in their respective tabs (`charitiesPage.tsx`).
* Added imports for the new tab components in `charitiesPage.tsx`.

**New tab component implementations:**

* Implemented `HopeKidsTab` with detailed information and a donation link for HopeKids, Inc. (`hopeKidsTab.tsx`).
* Added `McDonaldHouseTab` and `ArisFoundation` components as placeholders with "More info coming soon!" messages. (`mcDonaldHouseTab.tsx`, `arisFoundation.tsx`) [[1]](diffhunk://#diff-77b887362ea23ef3b6cc97de6eb40d4632089157f8f47bf4f3025874c0513ec6R1-R12) [[2]](diffhunk://#diff-72bbb770ff0a9435515343a576c2f6596b9e82c7b14978ce604a06f0f33b1279R1-R12)

**Styling improvements:**

* Updated the `CustomTabPanel` to center tab content using flexbox for improved layout consistency. (`charitiesPage.tsx`)